### PR TITLE
fix firefox bug

### DIFF
--- a/marquee.js
+++ b/marquee.js
@@ -74,7 +74,7 @@ var Marquee = function (element, defaults) {
 	this.start = function () {
         process = window.setInterval(function () {
            self.play();
-        });
+        }, 10);
     };
 
 	this.play = function() {


### PR DESCRIPTION
Added a delay of 10 milliseconds to setInterval. Previously, setInterval delay was empty and Firefox would only execute the play method once.